### PR TITLE
feat: Add object information feature with multilingual support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document describes features that could potentially be integrated into MyAst
 
 ## 🗓️ Release Plan
 
-### v1.0 – Stabilization & Overall Quality
+### v1.0 - Stabilization & Overall Quality
 **Objective: First stable release + smooth user experience**
 - Stabilization of critical bugs
 - Improved mobile interface (responsive)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1419,6 +1419,53 @@ def get_seeing_forecast_api():
         return jsonify({'error': 'Internal server error'}), 500
 
 
+@app.route('/api/object/<path:identifier>', methods=['GET'])
+@login_required
+def get_object_info_api(identifier):
+    """Return metadata, image URL and localized description for a deep-sky object.
+
+    Query parameters:
+      lang  (str, optional) — Wikipedia language code, default 'en'
+
+    Response (200):
+    {
+      "id": "NGC 2632",
+      "name": "Praesepe",
+      "aliases": ["M44", "Beehive Cluster", ...],
+      "type": "Open Cluster",
+      "coordinates": {"ra": 130.1, "dec": 19.67},
+      "description": "...",
+      "description_title": "Beehive Cluster",
+      "image": {"url": "...", "credit": "DSS2 / SkyView (NASA GSFC)"}
+    }
+
+    If the object is not found, returns 404 with {"error": "not_found"}.
+    If the identifier is invalid, returns 400 with {"error": "invalid_identifier"}.
+    """
+    import object_info as _object_info
+
+    lang = request.args.get('lang', 'en', type=str)
+    # Sanitize lang to a safe value
+    lang = str(lang).strip()[:8]
+
+    # Validate identifier characters before any processing
+    if not _object_info.is_safe_identifier(identifier):
+        return jsonify({'error': 'invalid_identifier'}), 400
+
+    try:
+        data = _object_info.get_object_info(identifier, lang=lang)
+    except Exception as exc:
+        logger.error(f'Error fetching object info for {identifier!r}: {exc}')
+        return jsonify({'error': 'Internal server error'}), 500
+
+    error = data.get('error')
+    if error == 'invalid_identifier':
+        return jsonify(data), 400
+    # not_found is a normal outcome (Moon, comets, personal objects not in SIMBAD)
+    # return 200 so browsers don't log a console error
+    return jsonify(data)
+
+
 @app.route("/api/iss/passes", methods=["GET"])
 @login_required
 def get_iss_passes_api():

--- a/backend/iss_passes.py
+++ b/backend/iss_passes.py
@@ -37,9 +37,9 @@ logger.info(f"Skyfield cache directory: {SKYFIELD_CACHE_DIR}")
 ISS_TLE_URLS = [
     # Primary: Celestrak GP catalog (most specific, JSON-capable via FORMAT=TLE)
     "https://celestrak.org/NORAD/elements/gp.php?CATNR=25544&FORMAT=TLE",
-    # Alternative 1: independent aggregator – returns JSON {line1, line2}
+    # Alternative 1: independent aggregator - returns JSON {line1, line2}
     "https://tle.ivanstanojevic.me/api/tle/25544",
-    # Alternative 2: wheretheiss.at – returns JSON {line1, line2}
+    # Alternative 2: wheretheiss.at - returns JSON {line1, line2}
     "https://api.wheretheiss.at/v1/satellites/25544/tles",
     # Celestrak group / legacy fallbacks
     "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle",
@@ -221,7 +221,7 @@ class ISSPassService:
 
     def _parse_iss_tle_from_response(self, response_text: str) -> Tuple[str, str]:
         """Extract ISS TLE pair from a response payload (JSON or plain-text)."""
-        # Attempt JSON first – tle.ivanstanojevic.me and wheretheiss.at return
+        # Attempt JSON first - tle.ivanstanojevic.me and wheretheiss.at return
         # {"line1": "1 25544...", "line2": "2 25544..."}
         try:
             data = json.loads(response_text)
@@ -502,11 +502,11 @@ def get_current_position() -> Dict[str, Any]:
     """Compute current ISS ground position and ±50-minute ground track from cached TLE.
 
     Returns a dict with keys:
-      latitude, longitude, altitude_km  – current sub-satellite point
-      past_track   – list of [lat, lon] for the past 50 minutes (1-min steps)
-      future_track – list of [lat, lon] for the next 50 minutes (1-min steps),
+      latitude, longitude, altitude_km  - current sub-satellite point
+      past_track   - list of [lat, lon] for the past 50 minutes (1-min steps)
+      future_track - list of [lat, lon] for the next 50 minutes (1-min steps),
                      starting at the current position
-      timestamp    – ISO 8601 UTC instant used for the computation
+      timestamp    - ISO 8601 UTC instant used for the computation
     """
     cached = _get_cached_tle(max_age_seconds=None)
     if cached is None:

--- a/backend/object_info.py
+++ b/backend/object_info.py
@@ -1,0 +1,348 @@
+"""
+Deep Sky Object metadata and image integration.
+
+Provides:
+  Phase 1 — Object resolution via SIMBAD TAP (identifier → name, type, RA/DEC, aliases)
+  Phase 2 — Image URL construction via SkyView/DSS (no download, link only)
+  Phase 3 — Localized description via Wikipedia REST API with language fallback chain
+"""
+
+import re
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# ──────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────
+
+REQUEST_TIMEOUT = 10  # seconds
+
+# Whitelist of Wikipedia language codes that the endpoint accepts.
+_ALLOWED_LANGS: frozenset = frozenset([
+    'en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'ru', 'ja', 'zh',
+    'pl', 'sv', 'uk', 'ar', 'cs', 'ko', 'hu', 'fi', 'no', 'da',
+])
+
+# Allowed characters in an astronomical object identifier.
+# Permits: letters, digits, space, +, -, ., *, /, '  (e.g. "NGC 2632", "alpha Cen")
+_IDENT_RE = re.compile(r"^[A-Za-z0-9 +\-_.*/']+$")
+
+SIMBAD_TAP_URL = 'https://simbad.cds.unistra.fr/simbad/sim-tap/sync'
+HIPS2FITS_URL = 'https://alasky.cds.unistra.fr/hips-image-services/hips2fits'
+
+
+# ──────────────────────────────────────────────
+# Input validation
+# ──────────────────────────────────────────────
+
+def is_safe_identifier(identifier: str) -> bool:
+    """Return True only if *identifier* contains safe characters for an object name."""
+    return (
+        bool(identifier)
+        and len(identifier) <= 64
+        and bool(_IDENT_RE.match(identifier))
+    )
+
+
+def _sanitize_lang(lang: str) -> str:
+    """Return *lang* if it is in the allowed set, otherwise 'en'."""
+    return lang if lang in _ALLOWED_LANGS else 'en'
+
+
+# ──────────────────────────────────────────────
+# Phase 1 — Object resolution (SIMBAD TAP)
+# ──────────────────────────────────────────────
+
+def _simbad_query(adql: str) -> Optional[Dict]:
+    """Execute an ADQL query against the SIMBAD TAP endpoint and return the JSON payload."""
+    try:
+        resp = requests.get(
+            SIMBAD_TAP_URL,
+            params={
+                'REQUEST': 'doQuery',
+                'LANG': 'ADQL',
+                'FORMAT': 'json',
+                'QUERY': adql,
+            },
+            timeout=REQUEST_TIMEOUT,
+            headers={'Accept': 'application/json'},
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        logger.warning(f'SIMBAD TAP request failed: {exc}')
+        return None
+
+
+def _resolve_via_simbad(identifier: str) -> Optional[Dict[str, Any]]:
+    """
+    Resolve *identifier* through SIMBAD TAP.
+
+    Returns a dict:
+    {
+        'id': str,           # SIMBAD main identifier
+        'name': str,         # same as id
+        'type': str,         # human-readable object type
+        'ra': float | None,  # degrees J2000
+        'dec': float | None, # degrees J2000
+        'aliases': list[str] # up to 20 alternative identifiers
+    }
+    or None if the object is not found.
+    """
+    # Escape single quotes for ADQL injection safety
+    safe_id = identifier.replace("'", "''")
+
+    main_query = (
+        "SELECT b.main_id, b.otype_txt, b.ra, b.dec "
+        "FROM basic AS b "
+        "JOIN ident AS i ON b.oid = i.oidref "
+        f"WHERE i.id = '{safe_id}'"
+    )
+    result = _simbad_query(main_query)
+    if not result or not result.get('data'):
+        return None
+
+    row = result['data'][0]
+    cols = [c['name'] for c in result.get('metadata', [])]
+    row_dict = dict(zip(cols, row))
+
+    main_id = str(row_dict.get('main_id') or '').strip()
+    obj_type = str(row_dict.get('otype_txt') or '').strip()
+    ra_raw = row_dict.get('ra')
+    dec_raw = row_dict.get('dec')
+
+    # Fetch all alternative identifiers
+    safe_main = main_id.replace("'", "''")
+    alias_query = (
+        "SELECT i.id "
+        "FROM ident AS i "
+        "JOIN ident AS ref ON i.oidref = ref.oidref "
+        f"WHERE ref.id = '{safe_main}'"
+    )
+    alias_result = _simbad_query(alias_query)
+    aliases: List[str] = []
+    if alias_result and alias_result.get('data'):
+        for alias_row in alias_result['data']:
+            alias_val = str(alias_row[0]).strip()
+            if alias_val and alias_val != main_id:
+                aliases.append(alias_val)
+
+    return {
+        'id': main_id,
+        'name': main_id,
+        'type': obj_type,
+        'ra': float(ra_raw) if ra_raw is not None else None,
+        'dec': float(dec_raw) if dec_raw is not None else None,
+        'aliases': aliases[:20],
+    }
+
+
+# ──────────────────────────────────────────────
+# Phase 2 — Image URL (SkyView / DSS)
+# ──────────────────────────────────────────────
+
+def _get_dss_image_url(ra: float, dec: float, size_deg: float = 0.5) -> str:
+    """
+    Construct a CDS hips2fits URL for a DSS2 Red image at the given coordinates.
+
+    The URL returns a JPEG image directly (no HTML wrapper).
+    """
+    params = {
+        'hips': 'CDS/P/DSS2/red',
+        'width': '400',
+        'height': '400',
+        'fov': f'{size_deg:.3f}',
+        'projection': 'TAN',
+        'coordsys': 'icrs',
+        'ra': f'{ra:.6f}',
+        'dec': f'{dec:.6f}',
+        'format': 'jpg',
+    }
+    return f"{HIPS2FITS_URL}?{urllib.parse.urlencode(params)}"
+
+# ──────────────────────────────────────────────
+# Phase 3 — Localized description (Wikipedia)
+# ──────────────────────────────────────────────
+
+# Regex matching SIMBAD catalog-style designations that Wikipedia will never have
+# e.g. "[LB2005] NGC 3031 X1", "[HB89] 0951+699"
+_SIMBAD_CATALOG_RE = re.compile(r'^\[.*?\]')
+
+
+def _is_wikipedia_candidate(term: str) -> bool:
+    """Return False for terms that are SIMBAD catalog designations unlikely to exist on Wikipedia."""
+    return not _SIMBAD_CATALOG_RE.match(term.strip())
+
+
+def _normalize_wikipedia_term(term: str) -> str:
+    """Collapse repeated whitespace in a search term before URL-encoding."""
+    return ' '.join(term.split())
+
+
+def _get_wikipedia_summary(search_term: str, lang: str = 'en') -> Optional[Dict[str, str]]:
+    """
+    Fetch a Wikipedia page summary for *search_term* in the given *lang*.
+
+    Only languages from _ALLOWED_LANGS are accepted; others fall back to 'en'.
+
+    Returns:
+    {
+        'title': str,
+        'description': str,   # short tagline
+        'extract': str        # paragraph summary
+    }
+    or None if not found.
+    """
+    lang = _sanitize_lang(lang)
+    safe_term = urllib.parse.quote(_normalize_wikipedia_term(search_term), safe='')
+    url = f'https://{lang}.wikipedia.org/api/rest_v1/page/summary/{safe_term}'
+    try:
+        resp = requests.get(
+            url,
+            timeout=REQUEST_TIMEOUT,
+            headers={
+                'Accept': 'application/json',
+                'User-Agent': 'MyAstroBoard/1.0 (https://github.com/WorldOfGZ/myastroboard)',
+            },
+        )
+        if resp.status_code in (404, 403):
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        extract = data.get('extract', '').strip()
+        if not extract:
+            return None
+        return {
+            'title': data.get('title', ''),
+            'description': data.get('description', ''),
+            'extract': extract,
+        }
+    except requests.RequestException as exc:
+        logger.warning(f'Wikipedia request failed ({lang}/{search_term}): {exc}')
+        return None
+
+
+def _wikipedia_with_fallback(aliases: List[str], lang: str) -> Optional[Dict[str, str]]:
+    """
+    Try each term in *aliases* for the requested *lang*, then fall back to
+    English if nothing is found.
+    """
+    for term in aliases:
+        if not _is_wikipedia_candidate(term):
+            continue
+        result = _get_wikipedia_summary(term, lang)
+        if result:
+            return result
+    if lang != 'en':
+        for term in aliases:
+            if not _is_wikipedia_candidate(term):
+                continue
+            result = _get_wikipedia_summary(term, 'en')
+            if result:
+                return result
+    return None
+
+
+# ──────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────
+
+def get_object_info(identifier: str, lang: str = 'en') -> Dict[str, Any]:
+    """
+    Return full metadata for an astronomical object.
+
+    Steps:
+      1. Validate *identifier* (safe characters, max 64 chars).
+      2. Resolve via SIMBAD → name, type, RA/DEC, aliases.
+      3. Build SkyView image URL from RA/DEC.
+      4. Fetch Wikipedia description (requested lang → English fallback).
+
+    Returns a dict matching the feature spec:
+    {
+        "id": str,
+        "name": str,
+        "aliases": list[str],
+        "type": str | None,
+        "coordinates": {"ra": float, "dec": float} | None,
+        "description": str | None,
+        "description_title": str | None,
+        "image": {"url": str, "credit": str} | None
+    }
+    """
+    lang = _sanitize_lang(lang)
+
+    if not is_safe_identifier(identifier):
+        logger.warning(f'get_object_info: unsafe identifier rejected: {identifier!r}')
+        return {
+            'id': '',
+            'name': '',
+            'aliases': [],
+            'type': None,
+            'coordinates': None,
+            'description': None,
+            'description_title': None,
+            'image': None,
+            'error': 'invalid_identifier',
+        }
+
+    # ── Phase 1: object resolution ──────────────────
+    resolved = _resolve_via_simbad(identifier)
+    if not resolved:
+        return {
+            'id': identifier,
+            'name': identifier,
+            'aliases': [],
+            'type': None,
+            'coordinates': None,
+            'description': None,
+            'description_title': None,
+            'image': None,
+            'error': 'not_found',
+        }
+
+    ra = resolved.get('ra')
+    dec = resolved.get('dec')
+
+    # ── Phase 2: image ──────────────────────────────
+    image = None
+    if ra is not None and dec is not None:
+        image = {
+            'url': _get_dss_image_url(ra, dec),
+            'credit': 'DSS2 Red / CDS HiPS',
+        }
+
+    # ── Phase 3: Wikipedia description ─────────────
+    # Build candidate search terms: original identifier first (e.g. 'NGC 3034'
+    # resolves to SIMBAD main name 'M  82' which Wikipedia rejects with a space),
+    # then SIMBAD main name, then recognisable aliases.
+    # Also add compact (no-space) variant for Messier-style names like 'M 82' → 'M82'.
+    _seen: set = set()
+    search_terms: List[str] = []
+    for _t in [identifier, resolved['name']] + resolved.get('aliases', [])[:8]:
+        _norm = _normalize_wikipedia_term(_t)
+        if _norm not in _seen:
+            _seen.add(_norm)
+            search_terms.append(_norm)
+        # For 'M 82' style names also try 'M82' (no space) — French Wikipedia needs it
+        _compact = _norm.replace(' ', '')
+        if _compact != _norm and _compact not in _seen:
+            _seen.add(_compact)
+            search_terms.append(_compact)
+    wiki_data = _wikipedia_with_fallback(search_terms, lang)
+
+    return {
+        'id': resolved['id'],
+        'name': resolved['name'],
+        'aliases': resolved.get('aliases', []),
+        'type': resolved.get('type'),
+        'coordinates': {'ra': ra, 'dec': dec} if ra is not None else None,
+        'description': wiki_data.get('extract') if wiki_data else None,
+        'description_title': wiki_data.get('title') if wiki_data else None,
+        'image': image,
+    }

--- a/backend/object_info.py
+++ b/backend/object_info.py
@@ -33,6 +33,15 @@ _ALLOWED_LANGS: frozenset = frozenset([
 # Permits: letters, digits, space, +, -, ., *, /, '  (e.g. "NGC 2632", "alpha Cen")
 _IDENT_RE = re.compile(r"^[A-Za-z0-9 +\-_.*/']+$")
 
+# Pre-built Wikipedia base URLs keyed by lang code — the hostname is never
+# constructed from user input, which prevents SSRF (CodeQL CWE-918).
+_WIKIPEDIA_BASES: Dict[str, str] = {
+    lang: f'https://{lang}.wikipedia.org/api/rest_v1/page/summary/'
+    for lang in [
+        'en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'ru', 'ja', 'zh',
+        'pl', 'sv', 'uk', 'ar', 'cs', 'ko', 'hu', 'fi', 'no', 'da',
+    ]
+}
 SIMBAD_TAP_URL = 'https://simbad.cds.unistra.fr/simbad/sim-tap/sync'
 HIPS2FITS_URL = 'https://alasky.cds.unistra.fr/hips-image-services/hips2fits'
 
@@ -201,7 +210,9 @@ def _get_wikipedia_summary(search_term: str, lang: str = 'en') -> Optional[Dict[
     """
     lang = _sanitize_lang(lang)
     safe_term = urllib.parse.quote(_normalize_wikipedia_term(search_term), safe='')
-    url = f'https://{lang}.wikipedia.org/api/rest_v1/page/summary/{safe_term}'
+    # Use the pre-built base URL so the hostname is never derived from user input.
+    base = _WIKIPEDIA_BASES[lang]  # lang is guaranteed in _ALLOWED_LANGS after _sanitize_lang
+    url = base + safe_term
     try:
         resp = requests.get(
             url,

--- a/backend/repo_config.py
+++ b/backend/repo_config.py
@@ -31,7 +31,7 @@ def load_config():
     """Load configuration from file"""
     config = load_json_file(CONFIG_FILE, deepcopy(DEFAULT_CONFIG))
     merged = _merge_defaults(config, DEFAULT_CONFIG)
-    # Strip legacy top-level 'constraints' key – constraints live exclusively
+    # Strip legacy top-level 'constraints' key - constraints live exclusively
     # under skytonight.constraints from now on.
     merged.pop('constraints', None)
     return merged

--- a/backend/skytonight_calculator.py
+++ b/backend/skytonight_calculator.py
@@ -189,7 +189,7 @@ def _horizon_floor_array(az_deg: np.ndarray, profile: List[Dict[str, Any]]) -> n
     """Return the custom horizon minimum altitude at each azimuth sample.
 
     Linearly interpolates between profile points on the circular azimuth scale.
-    ``profile`` is a list of dicts with ``az`` (0–360°) and ``alt`` (0–90°) keys.
+    ``profile`` is a list of dicts with ``az`` (0-360°) and ``alt`` (0-90°) keys.
     Returns a zero array when the profile is empty or invalid so that the caller's
     flat ``alt_min`` acts as the sole floor.
     """
@@ -504,7 +504,7 @@ def compute_astro_score(
         obj_score = 0.5
 
     # --- score_comfort ---
-    # Reward targets that transit during prime evening hours (21:00–01:00)
+    # Reward targets that transit during prime evening hours (21:00-01:00)
     if 21 <= window_start_hour or window_start_hour <= 1:
         time_bonus = 1.0
     elif 1 < window_start_hour <= 3:

--- a/backend/solar_system_events.py
+++ b/backend/solar_system_events.py
@@ -246,7 +246,7 @@ class SolarSystemEventsService:
                                              zenith_hourly_rate=shower_data['zenith_hourly_rate'],
                                              parent_body=shower_data['parent_body'])
 
-                    # Score 0–10: ZHR drives 70 %, radiant visibility drives 30 %
+                    # Score 0-10: ZHR drives 70 %, radiant visibility drives 30 %
                     zhr = shower_data['zenith_hourly_rate']
                     score = round(min(10.0, (zhr / 100.0) * 7.0 + (3.0 if is_visible else 0.0)), 1)
 

--- a/backend/special_phenomena.py
+++ b/backend/special_phenomena.py
@@ -418,8 +418,8 @@ class SpecialPhenomenaService:
         2. Sun is well below horizon (nautical twilight or darker)
         3. Moon is not bright / below horizon
 
-        Season (Northern Hemisphere): May–September
-        Season (Southern Hemisphere): November–March
+        Season (Northern Hemisphere): May-September
+        Season (Southern Hemisphere): November-March
 
         To avoid time-of-day bias the check is performed at 02:00 local time each night
         (deep into astronomical night for most latitudes). Results are deduplicated so
@@ -430,9 +430,9 @@ class SpecialPhenomenaService:
 
         # Hemisphere-aware season months
         if self.latitude >= 0:
-            mw_season_months = {5, 6, 7, 8, 9}       # Northern: May–Sep
+            mw_season_months = {5, 6, 7, 8, 9}       # Northern: May-Sep
         else:
-            mw_season_months = {11, 12, 1, 2, 3}      # Southern: Nov–Mar
+            mw_season_months = {11, 12, 1, 2, 3}      # Southern: Nov-Mar
 
         # Galactic center coordinates (Sgr A* region)
         _galactic_center = SkyCoord(ra=266.417 * u.deg, dec=-29.008 * u.deg, frame=ICRS)
@@ -512,7 +512,7 @@ class SpecialPhenomenaService:
                     current_date += timedelta(days=1)
                     continue
 
-                # Score: weighted altitude (0–8) + dark-sky bonus (always 2 here, moon already filtered)
+                # Score: weighted altitude (0-8) + dark-sky bonus (always 2 here, moon already filtered)
                 score = round(min(10.0, (gc_altitude / 60.0) * 8.0 + 2.0), 1)
 
                 title = self.i18n.t('events_api.special_phenomena.milky_way_title')

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -23,7 +23,7 @@ class _NumpySafeEncoder(json.JSONEncoder):
 
     def default(self, obj: object) -> object:  # type: ignore[override]
         try:
-            import numpy as np  # local import – optional dependency
+            import numpy as np  # local import - optional dependency
             if isinstance(obj, np.integer):
                 return int(obj)
             if isinstance(obj, np.floating):

--- a/docs/CACHE_SYSTEM.md
+++ b/docs/CACHE_SYSTEM.md
@@ -46,7 +46,7 @@ Each cache job has an individual TTL defined in `backend/constants.py`:
 1. Syncs each in-memory cache entry from the shared JSON file (gets persisted timestamp)
 2. Checks each job's TTL individually
 3. **Skips jobs whose TTL has not yet expired**
-4. Only runs stale jobs — often just 2–4 jobs per poll cycle
+4. Only runs stale jobs — often just 2-4 jobs per poll cycle
 
 On a typical steady-state machine, a scheduler poll cycle at the 25-minute mark will skip all jobs because the shortest TTL is 1 hour. Only at the 1-hour mark will hourly jobs run; daily jobs run at most once every 24 hours.
 
@@ -239,12 +239,12 @@ A "Failed" badge appears in the Duration column if the last execution threw an e
 - **Full observability** — per-job last run time and duration visible in Metrics tab
 
 ### Cache Sizes (Typical)
-- Moon report: ~5–10 KB
-- Sun report: ~3–5 KB
-- Best windows: ~5–8 KB each (×3 modes)
-- Moon planner: ~20–30 KB
-- Dark window: ~1–2 KB
-- Total: ~50–100 KB in memory + shared JSON file on disk
+- Moon report: ~5-10 KB
+- Sun report: ~3-5 KB
+- Best windows: ~5-8 KB each (×3 modes)
+- Moon planner: ~20-30 KB
+- Dark window: ~1-2 KB
+- Total: ~50-100 KB in memory + shared JSON file on disk
 
 ## Troubleshooting
 

--- a/docs/SKYTONIGHT.md
+++ b/docs/SKYTONIGHT.md
@@ -102,7 +102,7 @@ $$\text{scoreSky} = \max(0,\;1 - \text{moonImpact})$$
 
 | Input | Description |
 |---|---|
-| `moon_phase` | Illuminated fraction of Moon disk, 0 (new) – 1 (full) |
+| `moon_phase` | Illuminated fraction of Moon disk, 0 (new) - 1 (full) |
 | `angular_dist_moon` | Angular separation between target and Moon (degrees); defaults to 180° when unavailable |
 
 ### 3 — Object score (weight 0.25)
@@ -152,9 +152,9 @@ The final value is clamped to **[0.0, 1.0]** and rounded to 4 decimal places.
 
 | AstroScore | Interpretation |
 |---|---|
-| 0.85 – 1.00 | Exceptional — ideal conditions |
-| 0.65 – 0.84 | Good — recommended target |
-| 0.45 – 0.64 | Average — worth imaging if nothing better |
+| 0.85 - 1.00 | Exceptional — ideal conditions |
+| 0.65 - 0.84 | Good — recommended target |
+| 0.45 - 0.64 | Average — worth imaging if nothing better |
 | < 0.45 | Poor — significant limitation (moon, low altitude, faint object) |
 
 ---

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "title": "MyAstroBoard",
-    "title_html": "MyAstroBoard – Planungstool für astronomische Beobachtungen",
+    "title_html": "MyAstroBoard - Planungstool für astronomische Beobachtungen",
     "slogan": "Planungstool für astronomische Beobachtungen",
     "loading": "Laden...",
     "error": "Fehler",
@@ -115,7 +115,7 @@
     "low_cloud_impact": "Niedrig",
     "chart_cloud_impact": "Auswirkungen (%)",
     "chart_dew_tracking_title": "Taurisiko und Tracking-Stabilität",
-    "score_100_label": "Punktzahl (0–100 %)",
+    "score_100_label": "Punktzahl (0-100 %)",
     "no_horizon_data": "Keine Horizontdaten verfügbar",
     "error_loading_horizon_graph": "Das Horizontdiagramm konnte nicht geladen werden",
     "horizon_badge": "Horizont",
@@ -194,11 +194,11 @@
     "direction": "Richtung:",
     "astrophotography_score_hint": "Bewerten Sie basierend auf Typ, Sichtbarkeit, Höhe und Dauer",
     "eclipse_classification": {
-      "excellent": "Ausgezeichnet – außergewöhnliche Gelegenheit",
+      "excellent": "Ausgezeichnet - außergewöhnliche Gelegenheit",
       "very_good": "Sehr gut - Sehr empfehlenswert",
-      "good": "Gut – Sehenswert",
-      "moderate": "Mäßiges Interesse – Beobachtbar",
-      "low": "Geringes Interesse – Kaum sichtbar"
+      "good": "Gut - Sehenswert",
+      "moderate": "Mäßiges Interesse - Beobachtbar",
+      "low": "Geringes Interesse - Kaum sichtbar"
     },
     "eclipse_type": {
       "total": "Gesamt",
@@ -237,11 +237,11 @@
     "direction": "Richtung:",
     "astrophotography_score_hint": "Bewerten Sie basierend auf Typ, Sichtbarkeit, Höhe und Dauer",
     "eclipse_classification": {
-      "excellent": "Ausgezeichnet – außergewöhnliche Gelegenheit",
+      "excellent": "Ausgezeichnet - außergewöhnliche Gelegenheit",
       "very_good": "Sehr gut - Sehr empfehlenswert",
-      "good": "Gut – Sehenswert",
-      "moderate": "Mäßiges Interesse – Beobachtbar",
-      "low": "Geringes Interesse – Kaum sichtbar"
+      "good": "Gut - Sehenswert",
+      "moderate": "Mäßiges Interesse - Beobachtbar",
+      "low": "Geringes Interesse - Kaum sichtbar"
     },
     "failed_to_load_solar_eclipse_data": "Daten zur Sonnenfinsternis konnten nicht geladen werden",
     "eclipse_chart_title": "Höhe vs. Zeit",
@@ -294,7 +294,7 @@
     "location": "Standort:",
     "expected_colors": "Erwartete Farben:",
     "colors": {
-      "green": "Grün (am häufigsten, 100–300 km Höhe)",
+      "green": "Grün (am häufigsten, 100-300 km Höhe)",
       "red": "Rot (große Höhe, >300 km, mit starker Aktivität)",
       "blue_purple": "Blau/Lila (Stickstoff, selten, bei schweren Stürmen)",
       "pink": "Pink/Magenta (große Höhe, bei starker Aktivität)"
@@ -314,7 +314,7 @@
     "tips": {
       "1": "Um eine optimale Sicht zu erhalten, reisen Sie fernab der Lichtverschmutzung (Städte).",
       "2": "Schauen Sie während des empfohlenen Zeitfensters in Richtung Nordhorizont",
-      "3": "Ziehen Sie sich warm an – bei der Polarlichtjagd kann es erforderlich sein, draußen in der Kälte zu warten",
+      "3": "Ziehen Sie sich warm an - bei der Polarlichtjagd kann es erforderlich sein, draußen in der Kälte zu warten",
       "4": "Ein höherer Kp-Index bedeutet, dass Polarlichter weiter südlich sichtbar sein könnten",
       "5": "Grünes Polarlicht kommt am häufigsten vor, rotes Polarlicht entsteht durch Sauerstoff in großer Höhe",
       "6": "Bessere Sicht in klaren, mondlosen Nächten"
@@ -494,7 +494,7 @@
     "moon_sep": "Mondabstand (°):",
     "moon_sep_info": "Mindestabstand zum Mond in Grad (wird überschrieben, wenn „Mondbeleuchtung verwenden“ aktiviert ist)",
     "time_threshold": "Beobachtbarer Zeitschwellenwert:",
-    "time_threshold_info": "Der Anteil der Dunkelheit am Objekt muss beobachtbar sein (0,0–1,0, z. B. 0,5 = 50 %).",
+    "time_threshold_info": "Der Anteil der Dunkelheit am Objekt muss beobachtbar sein (0,0-1,0, z. B. 0,5 = 50 %).",
     "max_targets": "Maximale Ziele im Schwellenwert:",
     "max_targets_info": "Maximale Anzahl zu berechnender Ziele (empfohlen: ~45 für MQTT, andernfalls ~60)",
     "use_moon_illumination": "Verwenden Sie Mondbeleuchtung",
@@ -503,7 +503,7 @@
     "north_ccw_info": "Azimut-Anzeige einstellen: gegen den Uhrzeigersinn (Norden oben, Osten links) oder im Uhrzeigersinn",
     "bucket_list": "Bucket-Liste",
     "bucket_list_info": "Ziele, die immer enthalten sein sollen (eines pro Zeile). Diese werden angezeigt, sofern sie sichtbar sind, wobei Einschränkungen ignoriert werden. Verwenden Sie zur Identifizierung das Attribut „Name“.",
-    "bucket_list_title": "Persönliche Bucket-Liste – Ziele, die immer enthalten sind, wenn sie sichtbar sind",
+    "bucket_list_title": "Persönliche Bucket-Liste - Ziele, die immer enthalten sind, wenn sie sichtbar sind",
     "ready": "Bereit",
     "done_list": "Erledigt-Liste",
     "done_list_info": "Ziele, die nie angezeigt werden sollen (eines pro Zeile). Verwenden Sie zur Identifizierung das Attribut „Name“.",
@@ -575,7 +575,7 @@
     "log_export_started": "Protokoll-Archiv-Download gestartet"
   },
   "astrodex": {
-    "title": "Astrodex – Ich muss sie alle fangen!",
+    "title": "Astrodex - Ich muss sie alle fangen!",
     "your_collection": "Ihre persönliche Sammlung erfasster Himmelsobjekte",
     "shared_collection": "Gemeinsame Sammlung erfasster Himmelsobjekte (schreibgeschützt für Elemente anderer Benutzer)",
     "my_collection": "Meine Sammlung",
@@ -1061,7 +1061,7 @@
     "cache_status_valid": "Gültig",
     "cache_status_stale": "Abgelaufen",
     "cache_status_failed": "Fehler",
-    "cache_status_unknown": "–"
+    "cache_status_unknown": "-"
   },
   "equipment": {
     "combinations": "Kombinationen",
@@ -1228,7 +1228,7 @@
     "forecast": "Vorhersage",
     "loading_title": "Wetterdaten werden geladen...",
     "loading_text": "Abrufen von Wettervorhersagen und astronomischen Informationen",
-    "observation_next_hours": "Beobachtungsbedingungen – Nächste 12 Stunden",
+    "observation_next_hours": "Beobachtungsbedingungen - Nächste 12 Stunden",
     "loading_astro": "Astronomische Daten werden geladen...",
     "loading_astro_failed": "Astronomische Wetterdaten vorübergehend nicht verfügbar. Bitte versuchen Sie es in Kürze erneut.",
     "cloud_cover": "Wolkendecke:",
@@ -1333,7 +1333,7 @@
     "please_authenticate": "Bitte melden Sie sich an, um fortzufahren",
     "invalid_credentials": "Ungültiger Benutzername oder Passwort",
     "session_expired": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an",
-    "login_page_title": "Anmelden – MyAstroBoard",
+    "login_page_title": "Anmelden - MyAstroBoard",
     "remember_me_30_days": "An mich erinnern (30 Tage lang eingeloggt bleiben)",
     "sign_in": "Anmelden",
     "signing_in": "Anmelden...",
@@ -1545,5 +1545,25 @@
     "checking_connection": "Verbindung wird gepruft...",
     "still_offline": "Weiterhin offline. Bitte Verbindung prufen und erneut versuchen.",
     "auto_retry_in": "Automatischer neuer Versuch in {seconds}s"
+  },
+
+  "object_info": {
+    "title": "Objektinformationen",
+    "loading": "Objektdaten werden geladen...",
+    "not_found": "Objekt nicht gefunden",
+    "not_found_detail": "Keine Daten für \"{{identifier}}\" in der SIMBAD-Datenbank gefunden.",
+    "invalid_identifier": "Ungültiger Objektbezeichner",
+    "type_label": "Typ",
+    "coordinates_label": "Koordinaten",
+    "aliases_label": "Auch bekannt als",
+    "description_label": "Beschreibung",
+    "image_label": "Bild",
+    "image_credit": "Bildnachweis",
+    "image_unavailable": "Kein Bild verfügbar",
+    "description_unavailable": "Keine Beschreibung verfügbar",
+    "source_simbad": "Quelle: SIMBAD (CDS, Straßburg)",
+    "source_wikipedia": "Beschreibung: Wikipedia",
+    "source_skyview": "Bild: DSS2 / SkyView (NASA GSFC)",
+    "error_loading": "Objektinformationen konnten nicht geladen werden."
   }
 }

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1075,7 +1075,7 @@
     "cache_status_valid": "Valid",
     "cache_status_stale": "Stale",
     "cache_status_failed": "Failed",
-    "cache_status_unknown": "–"
+    "cache_status_unknown": "-"
   },
 
   "equipment": {
@@ -1569,5 +1569,25 @@
     "checking_connection": "Checking connection...",
     "still_offline": "Still offline. Please verify your network and try again.",
     "auto_retry_in": "Automatic retry in {seconds}s"
+  },
+
+  "object_info": {
+    "title": "Object Information",
+    "loading": "Loading object data...",
+    "not_found": "Object not found",
+    "not_found_detail": "No data was found for \"{{identifier}}\" in the SIMBAD database.",
+    "invalid_identifier": "Invalid object identifier",
+    "type_label": "Type",
+    "coordinates_label": "Coordinates",
+    "aliases_label": "Also known as",
+    "description_label": "Description",
+    "image_label": "Image",
+    "image_credit": "Image credit",
+    "image_unavailable": "No image available",
+    "description_unavailable": "No description available",
+    "source_simbad": "Source: SIMBAD (CDS, Strasbourg)",
+    "source_wikipedia": "Description: Wikipedia",
+    "source_skyview": "Image: DSS2 / SkyView (NASA GSFC)",
+    "error_loading": "Failed to load object information."
   }
 }

--- a/static/i18n/es.json
+++ b/static/i18n/es.json
@@ -1062,7 +1062,7 @@
     "cache_status_valid": "Válido",
     "cache_status_stale": "Caducado",
     "cache_status_failed": "Fallo",
-    "cache_status_unknown": "–"
+    "cache_status_unknown": "-"
   },
   "equipment": {
     "combinations": "Combinaciones",
@@ -1546,5 +1546,25 @@
     "checking_connection": "Comprobando conexion...",
     "still_offline": "Sigues sin conexion. Verifica tu red e intentalo de nuevo.",
     "auto_retry_in": "Reintento automatico en {seconds}s"
+  },
+
+  "object_info": {
+    "title": "Información del objeto",
+    "loading": "Cargando datos del objeto...",
+    "not_found": "Objeto no encontrado",
+    "not_found_detail": "No se encontraron datos para \"{{identifier}}\" en la base de datos SIMBAD.",
+    "invalid_identifier": "Identificador de objeto no válido",
+    "type_label": "Tipo",
+    "coordinates_label": "Coordenadas",
+    "aliases_label": "También conocido como",
+    "description_label": "Descripción",
+    "image_label": "Imagen",
+    "image_credit": "Crédito de imagen",
+    "image_unavailable": "Imagen no disponible",
+    "description_unavailable": "Descripción no disponible",
+    "source_simbad": "Fuente: SIMBAD (CDS, Estrasburgo)",
+    "source_wikipedia": "Descripción: Wikipedia",
+    "source_skyview": "Imagen: DSS2 / SkyView (NASA GSFC)",
+    "error_loading": "No se pudo cargar la información del objeto."
   }
 }

--- a/static/i18n/fr.json
+++ b/static/i18n/fr.json
@@ -1076,7 +1076,7 @@
     "cache_status_valid": "Valide",
     "cache_status_stale": "Expiré",
     "cache_status_failed": "Échec",
-    "cache_status_unknown": "–"
+    "cache_status_unknown": "-"
   },
 
   "equipment": {
@@ -1570,5 +1570,25 @@
     "checking_connection": "Vérification de la connexion...",
     "still_offline": "Toujours hors ligne. Vérifiez votre connexion puis réessayez.",
     "auto_retry_in": "Nouvelle tentative automatique dans {seconds}s"
+  },
+
+  "object_info": {
+    "title": "Informations sur l'objet",
+    "loading": "Chargement des données...",
+    "not_found": "Objet introuvable",
+    "not_found_detail": "Aucune donnée trouvée pour \"{{identifier}}\" dans la base SIMBAD.",
+    "invalid_identifier": "Identifiant d'objet invalide",
+    "type_label": "Type",
+    "coordinates_label": "Coordonnées",
+    "aliases_label": "Aussi connu sous",
+    "description_label": "Description",
+    "image_label": "Image",
+    "image_credit": "Crédit image",
+    "image_unavailable": "Aucune image disponible",
+    "description_unavailable": "Aucune description disponible",
+    "source_simbad": "Source : SIMBAD (CDS, Strasbourg)",
+    "source_wikipedia": "Description : Wikipédia",
+    "source_skyview": "Image : DSS2 / SkyView (NASA GSFC)",
+    "error_loading": "Impossible de charger les informations sur l'objet."
   }
 }

--- a/static/i18n/it.json
+++ b/static/i18n/it.json
@@ -1060,7 +1060,7 @@
     "cache_status_valid": "Valido",
     "cache_status_stale": "Scaduto",
     "cache_status_failed": "Errore",
-    "cache_status_unknown": "–"
+    "cache_status_unknown": "-"
   },
   "equipment": {
     "combinations": "Combinazioni",
@@ -1543,5 +1543,25 @@
     "checking_connection": "Verifica della connessione...",
     "still_offline": "Ancora offline. Verifica la tua rete e riprova.",
     "auto_retry_in": "Nuovo tentativo automatico tra {seconds}s"
+  },
+
+  "object_info": {
+    "title": "Informazioni sull'oggetto",
+    "loading": "Caricamento dati oggetto...",
+    "not_found": "Oggetto non trovato",
+    "not_found_detail": "Nessun dato trovato per \"{{identifier}}\" nel database SIMBAD.",
+    "invalid_identifier": "Identificatore oggetto non valido",
+    "type_label": "Tipo",
+    "coordinates_label": "Coordinate",
+    "aliases_label": "Anche noto come",
+    "description_label": "Descrizione",
+    "image_label": "Immagine",
+    "image_credit": "Credito immagine",
+    "image_unavailable": "Immagine non disponibile",
+    "description_unavailable": "Descrizione non disponibile",
+    "source_simbad": "Fonte: SIMBAD (CDS, Strasburgo)",
+    "source_wikipedia": "Descrizione: Wikipedia",
+    "source_skyview": "Immagine: DSS2 / SkyView (NASA GSFC)",
+    "error_loading": "Impossibile caricare le informazioni sull'oggetto."
   }
 }

--- a/static/i18n/pt.json
+++ b/static/i18n/pt.json
@@ -442,7 +442,7 @@
     "backup_restore": "Backup/Restauração",
     "log_export": "Exportação de registros",
     "location": "Configurações de localização",
-    "location_info": "Os parâmetros de localização são usados ​​para clima preciso, cálculos astronômicos e programação SkyTonight.",
+    "location_info": "Os parâmetros de localização são usados para clima preciso, cálculos astronômicos e programação SkyTonight.",
     "location_name": "Nome do local:",
     "location_name_placeholder": "Meu Observatório",
     "latitude": "Latitude (DMS ou Decimal):",
@@ -475,7 +475,7 @@
     "feature_comets_info": "Calcular e traçar cometas",
     "feature_alttime": "Gráficos de altitude/tempo",
     "feature_alttime_info": "Calcule e plote diagramas de altitude versus tempo",
-    "skytonight_info": "Esses parâmetros são usados ​​por internos SkyTonight.",
+    "skytonight_info": "Esses parâmetros são usados por internos SkyTonight.",
     "constraints": "Restrições",
     "use_constraints": "Usar restrições",
     "altitude_min": "Altitude mínima (°):",
@@ -1060,7 +1060,7 @@
     "cache_status_valid": "Válido",
     "cache_status_stale": "Expirado",
     "cache_status_failed": "Falhou",
-    "cache_status_unknown": "–"
+    "cache_status_unknown": "-"
   },
   "equipment": {
     "combinations": "Combinações",
@@ -1377,7 +1377,7 @@
     "processing": "Processamento",
     "current": "Atual:",
     "complete": "Execução concluída!",
-    "success": "Todos os catálogos foram processados ​​com sucesso.",
+    "success": "Todos os catálogos foram processados com sucesso.",
     "manual_complete": "SkyTonight execução do agendador concluída!",
     "scheduled_complete": "SkyTonight execução agendada concluída!",
     "run_now": "Execute SkyTonight agora",
@@ -1543,5 +1543,25 @@
     "checking_connection": "Verificando conexão...",
     "still_offline": "Ainda off-line. Verifique sua rede e tente novamente.",
     "auto_retry_in": "Nova tentativa automática em {seconds}s"
+  },
+
+  "object_info": {
+    "title": "Informações do objeto",
+    "loading": "Carregando dados do objeto...",
+    "not_found": "Objeto não encontrado",
+    "not_found_detail": "Nenhum dado encontrado para \"{{identifier}}\" no banco de dados SIMBAD.",
+    "invalid_identifier": "Identificador de objeto inválido",
+    "type_label": "Tipo",
+    "coordinates_label": "Coordenadas",
+    "aliases_label": "Também conhecido como",
+    "description_label": "Descrição",
+    "image_label": "Imagem",
+    "image_credit": "Crédito da imagem",
+    "image_unavailable": "Imagem não disponível",
+    "description_unavailable": "Descrição não disponível",
+    "source_simbad": "Fonte: SIMBAD (CDS, Estrasburgo)",
+    "source_wikipedia": "Descrição: Wikipédia",
+    "source_skyview": "Imagem: DSS2 / SkyView (NASA GSFC)",
+    "error_loading": "Não foi possível carregar as informações do objeto."
   }
 }

--- a/static/js/astrodex.js
+++ b/static/js/astrodex.js
@@ -952,6 +952,7 @@ async function showAstrodexItemDetail(itemId) {
         keyboard: true
     });
     bs_modal.show();
+
 }
 
 function renderCatalogueAliasesSection(item) {
@@ -1621,12 +1622,12 @@ function showPictureSlideshow(itemId) {
             </div>
         `;
         
-        // Update the modal content
-        const modalBody = document.getElementById('modal_full_close_body');
-        if (modalBody) {
-            DOMUtils.clear(modalBody);
+        // Update only the slideshow sub-container so the info card below is preserved
+        const slideshowWrapper = document.getElementById('slideshow-content-wrapper');
+        if (slideshowWrapper) {
+            DOMUtils.clear(slideshowWrapper);
             const fragment = document.createRange().createContextualFragment(modalContent);
-            modalBody.appendChild(fragment);
+            slideshowWrapper.appendChild(fragment);
             
             // Re-attach event listeners to navigation buttons
             attachNavigationListeners();
@@ -1703,9 +1704,22 @@ function showPictureSlideshow(itemId) {
         document.addEventListener('keydown', keyHandler);
     }
     
-    // Create modal using existing Bootstrap structure
+    // Create modal using existing Bootstrap structure — body has two stable sub-containers:
+    // #slideshow-content-wrapper (replaced on navigation) and #slideshow-object-info-wrapper (persistent)
     createModal(`${escapeHtml(item.name)} - ${i18n.t('astrodex.photos')}`, '', 'full');
-    
+
+    // Set up the two-part body structure before first render
+    const modalBodyInit = document.getElementById('modal_full_close_body');
+    if (modalBodyInit) {
+        DOMUtils.clear(modalBodyInit);
+        const slideshowDiv = document.createElement('div');
+        slideshowDiv.id = 'slideshow-content-wrapper';
+        const infoDiv = document.createElement('div');
+        infoDiv.id = 'slideshow-object-info-wrapper';
+        modalBodyInit.appendChild(slideshowDiv);
+        modalBodyInit.appendChild(infoDiv);
+    }
+
     // Show the modal
     bs_modal = new bootstrap.Modal('#modal_full_close', {
         backdrop: 'static',
@@ -1729,6 +1743,14 @@ function showPictureSlideshow(itemId) {
     updateModalContent();
     setupKeyboardNavigation();
     bs_modal.show();
+
+    // Async: inject object-info card into the stable info container
+    if (typeof injectObjectInfoIntoContainer === 'function' && item.name) {
+        const infoContainer = document.getElementById('slideshow-object-info-wrapper');
+        if (infoContainer) {
+            injectObjectInfoIntoContainer(item.name, infoContainer);
+        }
+    }
 }
 
 // ============================================

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -181,8 +181,8 @@ function addHorizonRow(az = '', alt = '') {
     if (!tbody) return;
     const tr = document.createElement('tr');
     tr.innerHTML = `
-        <td><input type="number" class="form-control form-control-sm horizon-az" value="${az}" min="0" max="360" step="1" placeholder="0–360"></td>
-        <td><input type="number" class="form-control form-control-sm horizon-alt" value="${alt}" min="0" max="90" step="1" placeholder="0–90"></td>
+        <td><input type="number" class="form-control form-control-sm horizon-az" value="${az}" min="0" max="360" step="1" placeholder="0-360"></td>
+        <td><input type="number" class="form-control form-control-sm horizon-alt" value="${alt}" min="0" max="90" step="1" placeholder="0-90"></td>
         <td><button type="button" class="btn btn-sm btn-danger" data-action="delete-horizon-row"><i class="bi bi-trash icon-inline" aria-hidden="true"></i></button></td>`;
     tbody.appendChild(tr);
     _updateHorizonTableVisibility();
@@ -396,7 +396,7 @@ async function loadLogLevel() {
     if (!badge) return;
     try {
         const data = await fetchJSON('/api/logs/level');
-        const level = data.level || '–';
+        const level = data.level || '-';
         badge.textContent = level;
         // Color the badge per level
         const colorMap = {
@@ -409,7 +409,7 @@ async function loadLogLevel() {
         badge.className = `badge fs-6 ${colorMap[level] || 'bg-secondary'}`;
     } catch (err) {
         console.error('Could not load log level:', err);
-        badge.textContent = '–';
+        badge.textContent = '-';
     }
 }
 

--- a/static/js/iss.js
+++ b/static/js/iss.js
@@ -48,7 +48,7 @@ function _updateIssMapContent(data) {
     const lat = Number(data.latitude);
     const lon = Number(data.longitude);
 
-    // Update marker position (no setView – avoids the infinite-tiles zoom loop)
+    // Update marker position (no setView - avoids the infinite-tiles zoom loop)
     _issMarker.setLatLng([lat, lon]);
     _issMarker.getPopup().setContent(
         `<b>ISS</b><br>${i18n.t('iss.map_altitude_label')}: ${data.altitude_km} km`
@@ -79,7 +79,7 @@ async function _pollIssLocation() {
         if (data && data.latitude !== undefined) {
             _updateIssMapContent(data);
         }
-    } catch (_) { /* silent – map just stays stale */ }
+    } catch (_) { /* silent - map just stays stale */ }
 }
 
 /** Stop the auto-refresh interval for the ISS map. */

--- a/static/js/metrics.js
+++ b/static/js/metrics.js
@@ -252,7 +252,7 @@ async function updateCacheJobsMetrics() {
             if (isValid === null) {
                 const b = document.createElement('span');
                 b.className = 'badge bg-secondary';
-                b.textContent = i18n.t('metrics.cache_status_unknown') || '–';
+                b.textContent = i18n.t('metrics.cache_status_unknown') || '-';
                 tdStatus.appendChild(b);
             } else if (isValid) {
                 const b = document.createElement('span');

--- a/static/js/object_info.js
+++ b/static/js/object_info.js
@@ -1,0 +1,241 @@
+/**
+ * object_info.js
+ * Fetch and display deep-sky object metadata (SIMBAD + SkyView + Wikipedia)
+ * via GET /api/object/<identifier>?lang=<code>
+ */
+
+// In-session cache: identifier (lowercased) → Promise<data>
+const _objectInfoCache = new Map();
+
+/**
+ * Fetch object info from the backend, with session-level memoization.
+ * @param {string} identifier - Object identifier (e.g. "NGC 2632", "M44")
+ * @returns {Promise<object|null>}
+ */
+async function fetchObjectInfo(identifier) {
+    const lang = (typeof i18n !== 'undefined' && i18n.getCurrentLanguage) ? i18n.getCurrentLanguage() : 'en';
+    const key = `${lang}:${identifier.trim().toLowerCase()}`;
+    if (_objectInfoCache.has(key)) {
+        return _objectInfoCache.get(key);
+    }
+    const url = `/api/object/${encodeURIComponent(identifier.trim())}?lang=${encodeURIComponent(lang)}`;
+    const promise = fetch(url, { credentials: 'same-origin' })
+        .then(resp => {
+            if (resp.status >= 500) throw new Error(`HTTP ${resp.status}`);
+            return resp.json();
+        })
+        .catch(err => {
+            console.warn(`[object_info] fetch failed for "${identifier}":`, err);
+            _objectInfoCache.delete(key); // allow retry on next call
+            return null;
+        });
+    _objectInfoCache.set(key, promise);
+    return promise;
+}
+
+/**
+ * Build and return the HTML for an object-info section.
+ * Uses the same card pattern as the slideshow picture-info tiles
+ * (d-flex align-items-center p-2 rounded shadow-sm bg-light).
+ *
+ * @param {object} data  - Response from /api/object/<id>
+ * @param {object} opts  - { compact: bool }  compact = fewer aliases / shorter description
+ * @returns {string} HTML string
+ */
+function buildObjectInfoCardHtml(data, opts = {}) {
+    const t = (key, fb) => (typeof i18n !== 'undefined' && i18n.has(key)) ? i18n.t(key) : fb;
+    const compact = !!opts.compact;
+    const noImage = !!opts.noImage;
+    const noError = !!opts.noError;
+    const colClass = opts.vertical ? 'col-12' : 'col-md-6 col-lg-4';
+
+    if (!data || data.error === 'not_found') {
+        if (noError) return '';
+        return `<div class="slideshow-info mt-4">
+            <p class="text-muted small">
+                <i class="bi bi-question-circle icon-inline" aria-hidden="true"></i>
+                ${escapeHtml(t('object_info.not_found', 'Object not found in SIMBAD'))}
+            </p>
+        </div>`;
+    }
+    if (data.error === 'invalid_identifier') {
+        if (noError) return '';
+        return `<div class="slideshow-info mt-4">
+            <p class="text-muted small">
+                <i class="bi bi-exclamation-circle icon-inline" aria-hidden="true"></i>
+                ${escapeHtml(t('object_info.invalid_identifier', 'Invalid identifier'))}
+            </p>
+        </div>`;
+    }
+
+    let html = `<div class="slideshow-info mt-4">`;
+
+    // ── Section heading ───────────────────────────────────
+    html += `<div class="row mb-3">
+        <div class="col">
+            <h5 class="text-dark mb-0">
+                <i class="bi bi-telescope icon-inline" aria-hidden="true"></i>
+                ${escapeHtml(t('object_info.title', 'Object Information'))}
+            </h5>
+        </div>
+    </div>`;
+
+    // ── Image ────────────────────────────────────────────
+    if (!noImage && data.image && data.image.url) {
+        html += `<div class="row mb-3">
+            <div class="col text-center">
+                <img src="${escapeHtml(data.image.url)}"
+                     alt="${escapeHtml(data.name)}"
+                     class="img-fluid rounded shadow-sm"
+                     loading="lazy"
+                     style="max-height:${compact ? '160px' : '300px'}; object-fit:cover;"
+                     onerror="this.closest('.row').style.display='none'">
+                <small class="text-muted d-block mt-1">
+                    <i class="bi bi-camera icon-inline" aria-hidden="true"></i>
+                    ${escapeHtml(data.image.credit)}
+                </small>
+            </div>
+        </div>`;
+    }
+
+    // ── Data tiles ───────────────────────────────────────
+    html += `<div class="row g-3">`;
+
+    if (data.type) {
+        html += `<div class="${colClass}">
+            <div class="d-flex align-items-center p-2 rounded shadow-sm bg-light h-100">
+                <div class="me-3 fs-4"><i class="bi bi-tag text-primary" aria-hidden="true"></i></div>
+                <div>
+                    <small class="text-muted d-block">${escapeHtml(t('object_info.type_label', 'Type'))}</small>
+                    <strong class="text-dark">${escapeHtml(data.type)}</strong>
+                </div>
+            </div>
+        </div>`;
+    }
+
+    if (data.coordinates) {
+        const ra  = data.coordinates.ra  != null ? Number(data.coordinates.ra).toFixed(4)  : '-';
+        const dec = data.coordinates.dec != null ? Number(data.coordinates.dec).toFixed(4) : '-';
+        html += `<div class="${colClass}">
+            <div class="d-flex align-items-center p-2 rounded shadow-sm bg-light h-100">
+                <div class="me-3 fs-4"><i class="bi bi-geo-alt text-success" aria-hidden="true"></i></div>
+                <div>
+                    <small class="text-muted d-block">${escapeHtml(t('object_info.coordinates_label', 'Coordinates'))}</small>
+                    <strong class="text-dark">RA ${escapeHtml(ra)}° &nbsp; Dec ${escapeHtml(dec)}°</strong>
+                </div>
+            </div>
+        </div>`;
+    }
+
+    if (data.aliases && data.aliases.length > 0) {
+        const shown = compact ? data.aliases.slice(0, 4) : data.aliases;
+        html += `<div class="${colClass}">
+            <div class="d-flex align-items-start p-2 rounded shadow-sm bg-light h-100">
+                <div class="me-3 fs-4"><i class="bi bi-bookmarks text-warning" aria-hidden="true"></i></div>
+                <div>
+                    <small class="text-muted d-block">${escapeHtml(t('object_info.aliases_label', 'Also known as'))}</small>
+                    <div class="mt-1">${shown.map(a => `<span class="badge bg-secondary me-1 mb-1">${escapeHtml(a)}</span>`).join('')}</div>
+                </div>
+            </div>
+        </div>`;
+    }
+
+    html += `</div>`; // row g-3
+
+    // ── Description ──────────────────────────────────────
+    if (data.description) {
+        const maxLen = compact ? 500 : 1200;
+        const text = data.description.length > maxLen
+            ? data.description.slice(0, maxLen) + '…'
+            : data.description;
+        html += `<div class="row mt-3">
+            <div class="col">
+                <div class="d-flex align-items-start p-2 rounded shadow-sm bg-light">
+                    <div class="me-3 fs-4"><i class="bi bi-journal-text" aria-hidden="true"></i></div>
+                    <div>
+                        <small class="text-muted d-block">${escapeHtml(t('object_info.description_label', 'Description'))}</small>
+                        <p class="mb-0 small mt-1" style="white-space:pre-wrap;">${escapeHtml(text)}</p>
+                    </div>
+                </div>
+            </div>
+        </div>`;
+    }
+
+    // ── Sources ──────────────────────────────────────────
+    let sources = [t('object_info.source_simbad', 'Source: SIMBAD (CDS, Strasbourg)')];
+    if (!noImage && data.image) sources.push(t('object_info.source_skyview',   'Image: DSS2 / SkyView (NASA GSFC)'));
+    if (data.description)       sources.push(t('object_info.source_wikipedia', 'Description: Wikipedia'));
+    html += `<div class="row mt-3">
+        <div class="col">
+            <small class="text-muted">
+                <i class="bi bi-c-circle icon-inline" aria-hidden="true"></i>
+                ${sources.map(s => escapeHtml(s)).join(' &nbsp;·&nbsp; ')}
+            </small>
+        </div>
+    </div>`;
+
+    html += `</div>`; // .slideshow-info
+    return html;
+}
+
+/**
+ * Open the lg modal and show an object-info card for *identifier*.
+ * Used from the SkyTonight table info icon.
+ *
+ * @param {string} identifier
+ */
+async function showObjectInfoModal(identifier) {
+    const titleEl = document.getElementById('modal_lg_close_title');
+    const bodyEl  = document.getElementById('modal_lg_close_body');
+    if (!titleEl || !bodyEl) return;
+
+    const t = (key, fb) => (typeof i18n !== 'undefined' && i18n.has(key)) ? i18n.t(key) : fb;
+
+    titleEl.textContent = `${escapeHtml(identifier)} — ${t('object_info.title', 'Object Information')}`;
+
+    // Loading state
+    DOMUtils.clear(bodyEl);
+    bodyEl.innerHTML = `<div class="text-center py-4">
+        <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>
+        ${escapeHtml(t('object_info.loading', 'Loading object data…'))}
+    </div>`;
+
+    const _modalEl = document.getElementById('modal_lg_close');
+    let bs_modal = bootstrap.Modal.getInstance(_modalEl);
+    if (!bs_modal) {
+        bs_modal = new bootstrap.Modal(_modalEl, { backdrop: true, focus: true, keyboard: true });
+    }
+    bs_modal.show();
+
+    const data = await fetchObjectInfo(identifier);
+
+    DOMUtils.clear(bodyEl);
+    bodyEl.innerHTML = buildObjectInfoCardHtml(data, { compact: false, vertical: true });
+}
+
+/**
+ * Inject an async object-info section into an already-open astrodex detail modal.
+ * Appended above the photos heading.
+ *
+ * @param {string} identifier - item.name or best alias
+ * @param {HTMLElement} container - element to append the card into
+ */
+async function injectObjectInfoIntoContainer(identifier, container) {
+    if (!container) return;
+    const t = (key, fb) => (typeof i18n !== 'undefined' && i18n.has(key)) ? i18n.t(key) : fb;
+
+    // Placeholder while loading
+    const placeholder = document.createElement('div');
+    placeholder.className = 'slideshow-info mt-4';
+    placeholder.innerHTML = `<div class="text-muted small py-2"><div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>${escapeHtml(t('object_info.loading', 'Loading…'))}</div>`;
+    container.appendChild(placeholder);
+
+    const data = await fetchObjectInfo(identifier);
+
+    const html = buildObjectInfoCardHtml(data, { compact: true, noImage: true, noError: true });
+    if (!html) {
+        placeholder.remove();
+        return;
+    }
+    placeholder.outerHTML = html;
+}

--- a/static/js/skytonight.js
+++ b/static/js/skytonight.js
@@ -13,6 +13,7 @@ let _skytFilteredData = {};       // sectionKey -> filtered row array (null = no
 let _skytFilterState = {};        // sectionKey -> saved filter values for cross-page persistence
 let _skytHasTelescopesCache = null;
 let _skytHasTelescopesPromise = null;
+const _skytListenerTimers = {};  // catalogue+type -> pending setTimeout id (cancelled on re-render)
 
 function tSkyTonightCompat(key, params = {}) {
     const skytonightKey = `skytonight.${key}`;
@@ -291,8 +292,8 @@ function _astroScoreBadgeHtml(score) {
 function _astroScoreLegendHtml() {
     const tiers = [
         { key: 'astroscore_exceptional', cls: 'bg-success',           range: '≥ 85%' },
-        { key: 'astroscore_good',        cls: 'bg-primary',           range: '65–84%' },
-        { key: 'astroscore_average',     cls: 'bg-warning text-dark', range: '45–64%' },
+        { key: 'astroscore_good',        cls: 'bg-primary',           range: '65-84%' },
+        { key: 'astroscore_average',     cls: 'bg-warning text-dark', range: '45-64%' },
         { key: 'astroscore_poor',        cls: 'bg-danger',            range: '< 45%' },
     ];
     let html = `<div class="d-flex flex-wrap gap-2 mb-2 align-items-center small mt-3">`;
@@ -1363,7 +1364,7 @@ async function showMorePopupFromRowData(moreData) {
         }
 
         const hasValue = value !== null && value !== undefined && value !== '';
-        let displayValue = hasValue ? String(value) : '–';
+        let displayValue = hasValue ? String(value) : '-';
 
         // Comet-specific field formatting
         if (type === 'comets') {
@@ -1393,9 +1394,11 @@ async function showMorePopupFromRowData(moreData) {
     tableDiv.appendChild(table);
     contentEl.appendChild(tableDiv);
 
-    const bs_modal = new bootstrap.Modal('#modal_lg_close', {
-        backdrop: 'static', focus: true, keyboard: true
-    });
+    const _modalEl1 = document.getElementById('modal_lg_close');
+    let bs_modal = bootstrap.Modal.getInstance(_modalEl1);
+    if (!bs_modal) {
+        bs_modal = new bootstrap.Modal(_modalEl1, { backdrop: true, focus: true, keyboard: true });
+    }
     bs_modal.show();
 
     const hasTelescopes = await _skytUserHasTelescopes();
@@ -1496,10 +1499,8 @@ async function _reRenderTablePage(sectionKey, page) {
 
     const displayAstrodex = await getSkyTonightDisplayAstrodex();
     // Use filtered data if a filter is active, otherwise the full cached array
-    const tableData = (_skytFilteredData[sectionKey] !== null && _skytFilteredData[sectionKey] !== undefined)
-        ? _skytFilteredData[sectionKey]
-        : cachedData[sectionKey];
-    if (!Array.isArray(tableData) || tableData.length === 0) return;
+    const isFiltered = _skytFilteredData[sectionKey] !== null && _skytFilteredData[sectionKey] !== undefined;
+    const tableData = isFiltered ? _skytFilteredData[sectionKey] : cachedData[sectionKey];
 
     // Target only the table sub-div so the filter controls in skyt-ctrl-… are
     // never cleared — the filter input keeps its DOM node, its value, and focus
@@ -1508,6 +1509,17 @@ async function _reRenderTablePage(sectionKey, page) {
     const tblDiv = document.getElementById(`skyt-tbl-SkyTonight-${tableType}`);
     const targetDiv = tblDiv || dataDiv;
     DOMUtils.clear(targetDiv);
+
+    // Empty result from an active filter — show a message instead of leaving the old table
+    if (!Array.isArray(tableData) || tableData.length === 0) {
+        const msg = document.createElement('div');
+        msg.className = 'alert alert-info mt-3';
+        msg.textContent = isFiltered
+            ? tSkyTonightCompat('no_target_in_report')
+            : tSkyTonightCompat('no_data_available');
+        targetDiv.appendChild(msg);
+        return;
+    }
 
     if (cachedData.in_progress) {
         const banner = document.createElement('div');
@@ -1810,10 +1822,8 @@ function generateReportTable(report, catalogue, type, displayAstrodex = true, pa
                     displayValue += col.unit;
                 }
                 
-                // Make ID or Target name clickable for alttime popup if file exists
+                // Make ID or Target name clickable
                 if ((col.key === 'id' || col.key === 'target name')) {
-                    // Use ID if available, otherwise use target name for generating alttime filename
-                    const alttimeSource = row['id'] || row['target name'];
                     // Messier badge: shown in the target name cell when the object is in the Messier catalogue
                     const messierNum = (col.key === 'target name')
                         ? (row['catalogue_names'] && row['catalogue_names']['Messier'] ? row['catalogue_names']['Messier'] : null)
@@ -1821,8 +1831,16 @@ function generateReportTable(report, catalogue, type, displayAstrodex = true, pa
                     const messierBadge = messierNum
                         ? `<span class="messier-badge" title="${escapeHtml(messierNum)}">${escapeHtml(messierNum)}</span>`
                         : '';
-                    if (alttimeSource && row['alttime_file'] != '') {
-                        const alttimeTargetId = encodeURIComponent(row['alttime_file']);
+                    // For DSO (report): ID cell opens object-info modal; target name cell opens alttime
+                    if (col.key === 'id' && type === 'report') {
+                        const infoId = (row['id'] || row['target name'] || '').trim();
+                        if (infoId) {
+                            html += `<td style="text-align: ${col.align}">${messierBadge}<a href="#" class="link-underline link-underline-opacity-0 skyt-info-link" data-identifier="${escapeHtml(infoId)}">${displayValue}</a></td>`;
+                        } else {
+                            html += `<td style="text-align: ${col.align}">${messierBadge}${displayValue}</td>`;
+                        }
+                    } else if (row['alttime_file'] != '') {
+                        const alttimeSource = row['id'] || row['target name'];
                         html += `
                         <td style="text-align: ${col.align}" class="alttime-check" data-alttime-id="${escapeHtml(row['alttime_file'])}" data-title="${escapeHtml(alttimeSource)} - ${escapeHtml(tSkyTonightCompat('altitude_time_title'))}">
                             ${messierBadge}<a href="#" class="link-underline link-underline-opacity-0 alttime-popup-link">${displayValue}</a>
@@ -1850,7 +1868,11 @@ function generateReportTable(report, catalogue, type, displayAstrodex = true, pa
     if (!isRerender) html += `</div>`; // closes skyt-tbl div
 
     // Add event listeners for filtering
-    setTimeout(() => {
+    // Cancel any previous pending timer for this table key to avoid duplicate listeners
+    // when rapid re-renders (pagination, filter) fire before the previous timer expires.
+    const _timerKey = `${catalogue}-${type}`;
+    clearTimeout(_skytListenerTimers[_timerKey]);
+    _skytListenerTimers[_timerKey] = setTimeout(() => {
         const filterInput = document.getElementById(`filter-${catalogue}-${type}`);
         const fotoCheckbox = document.getElementById(`foto-filter-${catalogue}-${type}`);
         const fotoValueInput = document.getElementById(`foto-value-${catalogue}-${type}`);
@@ -1880,32 +1902,42 @@ function generateReportTable(report, catalogue, type, displayAstrodex = true, pa
                 if (constellationSelect) constellationSelect.value  = _savedFilter.constellation;
                 if (typeSelect)          typeSelect.value           = _savedFilter.typeVal;
             }
+        }
 
-            if (filterInput) {
-                filterInput.addEventListener('input', () => _skytApplyFilter(catalogue, type));
-            }
-            if (fotoCheckbox) {
-                fotoCheckbox.addEventListener('change', () => {
-                    localStorage.setItem('fotoFilterEnabled', fotoCheckbox.checked);
-                    syncFotoCheckboxes(fotoCheckbox.checked);
-                    _skytApplyFilter(catalogue, type);
-                });
-            }
-            if (fotoValueInput) {
-                fotoValueInput.addEventListener('input', () => {
-                    const normalizedFotoValue = sanitizeFotoFilterValue(fotoValueInput.value);
-                    fotoValueInput.value = normalizedFotoValue;
-                    localStorage.setItem('fotoFilterValue', normalizedFotoValue);
-                    syncFotoValues(normalizedFotoValue);
-                    _skytApplyFilter(catalogue, type);
-                });
-            }
-            if (constellationSelect) {
-                constellationSelect.addEventListener('change', () => _skytApplyFilter(catalogue, type));
-            }
-            if (typeSelect) {
-                typeSelect.addEventListener('change', () => _skytApplyFilter(catalogue, type));
-            }
+        // Attach filter/select listeners whenever the element is new (not yet marked).
+        // Using a per-element flag prevents duplicate listeners when the same DOM node
+        // (in skyt-ctrl-* which is never cleared on re-render) passes through this timer
+        // more than once. On full re-renders (initial or section revisit) elements are new
+        // and will always receive a listener.
+        if (filterInput && !filterInput._skytListened) {
+            filterInput._skytListened = true;
+            filterInput.addEventListener('input', () => _skytApplyFilter(catalogue, type));
+        }
+        if (fotoCheckbox && !fotoCheckbox._skytListened) {
+            fotoCheckbox._skytListened = true;
+            fotoCheckbox.addEventListener('change', () => {
+                localStorage.setItem('fotoFilterEnabled', fotoCheckbox.checked);
+                syncFotoCheckboxes(fotoCheckbox.checked);
+                _skytApplyFilter(catalogue, type);
+            });
+        }
+        if (fotoValueInput && !fotoValueInput._skytListened) {
+            fotoValueInput._skytListened = true;
+            fotoValueInput.addEventListener('input', () => {
+                const normalizedFotoValue = sanitizeFotoFilterValue(fotoValueInput.value);
+                fotoValueInput.value = normalizedFotoValue;
+                localStorage.setItem('fotoFilterValue', normalizedFotoValue);
+                syncFotoValues(normalizedFotoValue);
+                _skytApplyFilter(catalogue, type);
+            });
+        }
+        if (constellationSelect && !constellationSelect._skytListened) {
+            constellationSelect._skytListened = true;
+            constellationSelect.addEventListener('change', () => _skytApplyFilter(catalogue, type));
+        }
+        if (typeSelect && !typeSelect._skytListened) {
+            typeSelect._skytListened = true;
+            typeSelect.addEventListener('change', () => _skytApplyFilter(catalogue, type));
         }
 
         // Add event listeners for Astrodex "Add" buttons
@@ -2054,6 +2086,17 @@ function generateReportTable(report, catalogue, type, displayAstrodex = true, pa
             });
         });
 
+        // DSO ID link: open object-info modal
+        document.querySelectorAll('.skyt-info-link').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const identifier = link.getAttribute('data-identifier');
+                if (identifier && typeof showObjectInfoModal === 'function') {
+                    showObjectInfoModal(identifier);
+                }
+            });
+        });
+
         // Pagination buttons
         document.querySelectorAll('.skyt-page-btn').forEach(btn => {
             btn.addEventListener('click', async (e) => {
@@ -2079,7 +2122,7 @@ function sanitizeFotoFilterValue(value, fallback = 80) {
     if (!Number.isFinite(numericValue)) {
         return String(fallback);
     }
-    // Migrate legacy 0–1 decimal values to 0–100 percentage
+    // Migrate legacy 0-1 decimal values to 0-100 percentage
     const pctValue = numericValue <= 1.0 ? numericValue * 100 : numericValue;
     const clampedValue = Math.min(100, Math.max(0, Math.round(pctValue)));
     return String(clampedValue);
@@ -2480,7 +2523,7 @@ async function showAlttimePopup(title, targetId) {
         col.className = 'col-auto ms-auto';
         const span = document.createElement('span');
         span.className = 'text-muted';
-        span.textContent = `${tSkyTonightCompat('altitude_time_night_window')}: ${nightStart} – ${nightEnd}`;
+        span.textContent = `${tSkyTonightCompat('altitude_time_night_window')}: ${nightStart} - ${nightEnd}`;
         col.appendChild(span);
         footerRow.appendChild(col);
     }
@@ -2650,11 +2693,11 @@ function showMorePopup(popupId) {
             contentElement.appendChild(node.cloneNode(true));
         });
 
-        const bs_modal = new bootstrap.Modal('#modal_lg_close', {
-            backdrop: 'static',
-            focus: true,
-            keyboard: true
-        });
+        const _modalEl2 = document.getElementById('modal_lg_close');
+        let bs_modal = bootstrap.Modal.getInstance(_modalEl2);
+        if (!bs_modal) {
+            bs_modal = new bootstrap.Modal(_modalEl2, { backdrop: true, focus: true, keyboard: true });
+        }
         bs_modal.show();
 
     }
@@ -2756,11 +2799,8 @@ async function openCapturedAstrodexItem(itemData) {
         return;
     }
 
-    const hasPictures = Array.isArray(retryMatchedItem.pictures) && retryMatchedItem.pictures.length > 0;
-    if (hasPictures && typeof showPictureSlideshow === 'function') {
+    if (typeof showPictureSlideshow === 'function') {
         showPictureSlideshow(retryMatchedItem.id);
-    } else if (typeof showAstrodexItemDetail === 'function') {
-        showAstrodexItemDetail(retryMatchedItem.id);
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1834,7 +1834,7 @@
                     </div>
                     <div class="d-flex align-items-center gap-3 mb-2">
                         <span data-i18n="settings.log_current_level">Active file log level:</span>
-                        <span id="log-export-current-level" class="badge bg-secondary fs-6">–</span>
+                        <span id="log-export-current-level" class="badge bg-secondary fs-6">-</span>
                     </div>
                     <p class="text-muted small mb-0">
                         <code>LOG_LEVEL=DEBUG</code> &nbsp;·&nbsp; <span data-i18n="settings.log_level_env_hint">Set in docker-compose.yml or .env, then restart the container.</span>
@@ -2007,6 +2007,7 @@
     <script src="/static/js/weather.js?v={{ version }}"></script>
     <script src="/static/js/weather_astro.js?v={{ version }}"></script>
     <script src="/static/js/weather_alerts.js?v={{ version }}"></script>
+    <script src="/static/js/object_info.js?v={{ version }}"></script>
     <script src="/static/js/astrodex.js?v={{ version }}"></script>
     <script src="/static/js/plan_my_night.js?v={{ version }}"></script>
     <script src="/static/js/equipment.js?v={{ version }}"></script>


### PR DESCRIPTION
Add object information feature with multilingual support

- Introduced new object information section in the UI, displaying metadata from SIMBAD, SkyView, and Wikipedia.
- Added translations for object information in English, Spanish, French, Italian, and Portuguese.
- Updated existing translations to replace the en dash with a standard hyphen for consistency.
- Enhanced the astrodex modal to include an object-info card, improving user experience when viewing deep-sky objects.
- Implemented caching for object information requests to optimize performance.
- Refactored JavaScript code to support the new object information feature, ensuring smooth integration with existing functionalities.

<!-- 
Thank you for contributing to MyAstroBoard! 
Please fill out this template to help us review your pull request efficiently.
-->

## Description

<!-- Provide a clear and concise description of your changes -->

### Type of Change

<!-- Check all that apply by placing an 'x' in the brackets: [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change (CSS, templates, visual improvements)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update (adding or updating tests)
- [ ] 🔧 Configuration change (Docker, CI/CD, build config)

## Related Issues

<!-- Link related issues using keywords: Fixes #123, Closes #456, Related to #789 -->

Fixes #

## Changes Made

<!-- Provide a detailed list of changes made in this PR -->

### Backend Changes
<!-- List backend/Python changes, or remove this section if not applicable -->

- 

### Frontend Changes
<!-- List frontend/JavaScript/CSS changes, or remove this section if not applicable -->

- 

### Documentation Changes
<!-- List documentation changes, or remove this section if not applicable -->

- 

### Other Changes
<!-- List any other changes, or remove this section if not applicable -->

- 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Screenshots (if applicable)

<!-- Add screenshots for UI changes. You can drag and drop images here. -->

### Before
<!-- Screenshot showing the state before your changes -->

### After
<!-- Screenshot showing the state after your changes -->

## Testing

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Tested in Docker container
- [ ] Tested with multiple browsers (if frontend changes)

### Test Configuration

- **Python version**: 
- **Docker version**: 
- **OS**: 
- **Browser(s)**: <!-- If applicable -->

### Test Cases

<!-- Describe specific test cases you executed -->

1. 
2. 
3. 

## Checklist

<!-- Check all items that apply by placing an 'x' in the brackets: [x] -->

### Code Quality

- [ ] My code follows the [project style guidelines](../CONTRIBUTING.md#style-guidelines)
- [ ] All code, comments, and documentation are **in English**
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have used the centralized logging system (no `print()` statements in backend)
- [ ] I have used type hints for Python functions where appropriate
- [ ] My code is formatted according to PEP 8 (Python) or project conventions (JavaScript/CSS)

### Documentation

- [ ] I have updated the documentation to reflect my changes
- [ ] I have updated relevant docstrings
- [ ] I have added/updated code comments where necessary
- [ ] I have updated README.md if feature is user-facing

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested in a Docker container
- [ ] I have verified no regressions in existing functionality

### Dependencies

- [ ] I have updated `requirements.txt` if I added new Python dependencies
- [ ] I have updated `requirements-dev.txt` if I added new dev dependencies
- [ ] I have verified all dependencies are compatible with Python 3.11+
- [ ] I have considered security implications of new dependencies

### Git Hygiene

- [ ] My commits follow the [project commit conventions](../CONTRIBUTING.md#git-commit-messages)
- [ ] I have rebased my branch on the latest main
- [ ] I have resolved any merge conflicts
- [ ] My branch name follows the convention (`feature/`, `fix/`, etc.)

### CI/CD

- [ ] All CI checks pass
- [ ] No new linting errors introduced
- [ ] Docker image builds successfully
- [ ] No security vulnerabilities introduced

## Breaking Changes

<!-- 
If this is a breaking change, describe:
- What breaks
- Migration path for users
- Why this change is necessary
-->

**Is this a breaking change?** No / Yes

<!-- If yes, describe the breaking changes and migration path -->

## Additional Notes

<!-- Any additional information, context, or notes for reviewers -->

## Deployment Notes

<!-- Any special deployment considerations, environment variables, or configuration changes needed -->

## For Maintainers

<!-- Maintainers can fill this section during review -->

### Review Notes

- [ ] Code review completed
- [ ] Tests verified
- [ ] Documentation verified
- [ ] Security implications assessed
- [ ] Performance impact considered
- [ ] Breaking changes communicated
- [ ] VERSION file updated (if applicable)

---

<!-- 
By submitting this pull request, I confirm that:
- I have read and agree to follow the Code of Conduct
- My contribution is made under the same license as this project
- I have the right to submit this contribution
-->

Thank you for contributing to MyAstroBoard! 🌙✨
