### PR TITLE
chore: clear CHANGELOG_NEXT after release v0.8.2

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,3 +1,0 @@
-- Update notification service to have more log
-- Modify encoding for google notification
-- Add search on log to simplify search of specific error


### PR DESCRIPTION
Automated cleanup after tagging release v0.8.2.