### PR TITLE
chore: clear CHANGELOG_NEXT after release v0.9.0

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,8 +1,0 @@
-> [!IMPORTANT]
-> From now, project migrated to org myastroboard/myastroboard
-
-- Notification language use now preference settings in users.json
-- Add credits section on About
-- Fix some date calculation due to fixed UTC Tz in docker compose
-- Improve offline detection/retry
-- Increase tests coverage


### PR DESCRIPTION
Automated cleanup after tagging release v0.9.0.