### PR TITLE
Add RASA as an option for scope type

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,4 +1,5 @@
 - Increale aperture limite and allow 2 decimal on reducer - Thanks @cgobat
+- Add RASA (Rowe Ackerman Schmidt Astrograph) as a telescope type option - Thanks @cgobat
 - Server side input verification for equipment
 - Fix log display on mobile view
 - Fix notification NaN when no astronomical night

--- a/backend/equipment_profiles.py
+++ b/backend/equipment_profiles.py
@@ -26,6 +26,7 @@ class TelescopeType(str, Enum):
     REFRACTOR = "Refractor"
     REFLECTOR = "Reflector"
     SCT = "Schmidt-Cassegrain (SCT)"
+    RASA = "Rowe Ackerman Schmidt Astrograph (RASA)"
     RC = "Ritchey-Chrétien (RC)"
     NEWTONIAN = "Newtonian"
     MAKSUTOV = "Maksutov-Cassegrain"

--- a/docs/EQUIPMENT.md
+++ b/docs/EQUIPMENT.md
@@ -27,7 +27,7 @@ Data is stored per-user in `data/equipments/<user_id>_<type>.json`.
 |-------|-------------|
 | `name` | Display name (e.g. "Celestron C8") |
 | `manufacturer` | Brand |
-| `telescope_type` | `Refractor`, `Reflector`, `Schmidt-Cassegrain (SCT)`, `Ritchey-Chrétien (RC)`, `Newtonian`, `Maksutov-Cassegrain`, `Cassegrain`, `Dobsonian` |
+| `telescope_type` | `Refractor`, `Reflector`, `Schmidt-Cassegrain (SCT)`, `Rowe Ackerman Schmidt Astrograph (RASA)`, `Ritchey-Chrétien (RC)`, `Newtonian`, `Maksutov-Cassegrain`, `Cassegrain`, `Dobsonian` |
 | `aperture_mm` | Clear aperture in mm |
 | `focal_length_mm` | Native focal length in mm |
 | `reducer_barlow_factor` | Focal reducer (< 1) or Barlow (> 1) factor; default 1.0 |

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1397,6 +1397,7 @@
     "form_refractor": "Refraktor",
     "form_reflector": "Reflektor",
     "form_sct": "Schmidt-Cassegrain (SCT)",
+    "form_rasa": "Rowe Ackerman Schmidt Astrograph (RASA)",
     "form_rc": "Ritchey-Chrétien (RC)",
     "form_newtonian": "Newtonian",
     "form_maksutov": "Maksutov-Cassegrain",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1397,6 +1397,7 @@
     "form_refractor": "Refractor",
     "form_reflector": "Reflector",
     "form_sct": "Schmidt-Cassegrain (SCT)",
+    "form_rasa": "Rowe Ackerman Schmidt Astrograph (RASA)",
     "form_rc": "Ritchey-Chrétien (RC)",
     "form_newtonian": "Newtonian",
     "form_maksutov": "Maksutov-Cassegrain",

--- a/static/i18n/es.json
+++ b/static/i18n/es.json
@@ -1397,6 +1397,7 @@
     "form_refractor": "Refractor",
     "form_reflector": "Reflector",
     "form_sct": "Schmidt-Cassegrain (SCT)",
+    "form_rasa": "Rowe Ackerman Schmidt Astrograph (RASA)",
     "form_rc": "Ritchey-Chrétien (RC)",
     "form_newtonian": "newtoniano",
     "form_maksutov": "Maksutov-Cassegrain",

--- a/static/i18n/fr.json
+++ b/static/i18n/fr.json
@@ -1397,6 +1397,7 @@
     "form_refractor": "Réfracteur",
     "form_reflector": "Réflecteur",
     "form_sct": "Schmidt-Cassegrain (SCT)",
+    "form_rasa": "Rowe Ackerman Schmidt Astrograph (RASA)",
     "form_rc": "Ritchey-Chrétien (RC)",
     "form_newtonian": "Newtonien",
     "form_maksutov": "Maksutov-Cassegrain",

--- a/static/i18n/it.json
+++ b/static/i18n/it.json
@@ -1397,6 +1397,7 @@
     "form_refractor": "Rifrattore",
     "form_reflector": "Riflettore",
     "form_sct": "Schmidt-Cassegrain (SCT)",
+    "form_rasa": "Rowe Ackerman Schmidt Astrograph (RASA)",
     "form_rc": "Ritchey-Chrétien (RC)",
     "form_newtonian": "Newtoniano",
     "form_maksutov": "Maksutov-Cassegrain",

--- a/static/i18n/pt.json
+++ b/static/i18n/pt.json
@@ -1397,6 +1397,7 @@
     "form_refractor": "Refrator",
     "form_reflector": "Refletor",
     "form_sct": "Schmidt-Cassegrain (SCT)",
+    "form_rasa": "Rowe Ackerman Schmidt Astrograph (RASA)",
     "form_rc": "Ritchey-Chrétien (RC)",
     "form_newtonian": "newtoniano",
     "form_maksutov": "Maksutov-Cassegrain",

--- a/static/js/equipment.js
+++ b/static/js/equipment.js
@@ -908,6 +908,7 @@ async function showTelescopeModal(id = null) {
                     <option value="Refractor" ${telescope?.telescope_type === 'Refractor' ? 'selected' : ''}>${i18n.t('equipment.form_refractor')}</option>
                     <option value="Reflector" ${telescope?.telescope_type === 'Reflector' ? 'selected' : ''}>${i18n.t('equipment.form_reflector')}</option>
                     <option value="Schmidt-Cassegrain (SCT)" ${telescope?.telescope_type === 'Schmidt-Cassegrain (SCT)' ? 'selected' : ''}>${i18n.t('equipment.form_sct')}</option>
+                    <option value="Rowe Ackerman Schmidt Astrograph (RASA)" ${telescope?.telescope_type === 'Rowe Ackerman Schmidt Astrograph (RASA)' ? 'selected' : ''}>${i18n.t('equipment.form_rasa')}</option>
                     <option value="Ritchey-Chrétien (RC)" ${telescope?.telescope_type === 'Ritchey-Chrétien (RC)' ? 'selected' : ''}>${i18n.t('equipment.form_rc')}</option>
                     <option value="Newtonian" ${telescope?.telescope_type === 'Newtonian' ? 'selected' : ''}>${i18n.t('equipment.form_newtonian')}</option>
                     <option value="Maksutov-Cassegrain" ${telescope?.telescope_type === 'Maksutov-Cassegrain' ? 'selected' : ''}>${i18n.t('equipment.form_maksutov')}</option>

--- a/tests/test_equipment_profiles.py
+++ b/tests/test_equipment_profiles.py
@@ -72,7 +72,38 @@ def test_create_rasa_telescope(temp_data_dir, test_user_id):
 
     assert telescope is not None
     assert telescope["telescope_type"] == equipment_profiles.TelescopeType.RASA.value
-    assert telescope["native_focal_ratio"] == 2.22
+    assert telescope["native_focal_ratio"] == round(620 / 279, 2)  # 2.22
+
+
+def test_update_rasa_telescope(temp_data_dir, test_user_id):
+    """Test updating a RASA telescope profile."""
+    telescope_data = {
+        "name": "Test RASA",
+        "telescope_type": "Rowe Ackerman Schmidt Astrograph (RASA)",
+        "aperture_mm": 279,
+        "focal_length_mm": 620,
+        "reducer_barlow_factor": 1.0,
+    }
+
+    created = equipment_profiles.create_telescope(test_user_id, telescope_data)
+
+    update_data = {
+        "name": "Updated RASA",
+        "telescope_type": "Rowe Ackerman Schmidt Astrograph (RASA)",
+        "aperture_mm": 279,
+        "focal_length_mm": 620,
+        "reducer_barlow_factor": 1.0,
+        "notes": "Updated notes",
+    }
+
+    updated = equipment_profiles.update_telescope(test_user_id, created["id"], update_data)
+
+    assert updated is not None
+    assert updated["name"] == "Updated RASA"
+    assert updated["telescope_type"] == equipment_profiles.TelescopeType.RASA.value
+    assert updated["native_focal_ratio"] == round(620 / 279, 2)
+    assert updated["notes"] == "Updated notes"
+
 
 def test_get_telescope(temp_data_dir, test_user_id):
     """Test retrieving a telescope profile"""

--- a/tests/test_equipment_profiles.py
+++ b/tests/test_equipment_profiles.py
@@ -58,6 +58,22 @@ def test_create_telescope(temp_data_dir, test_user_id):
     assert 'created_at' in telescope
 
 
+def test_create_rasa_telescope(temp_data_dir, test_user_id):
+    """Test creating a RASA telescope profile."""
+    telescope_data = {
+        "name": "Test RASA",
+        "telescope_type": "Rowe Ackerman Schmidt Astrograph (RASA)",
+        "aperture_mm": 279,
+        "focal_length_mm": 620,
+        "reducer_barlow_factor": 1.0,
+    }
+
+    telescope = equipment_profiles.create_telescope(test_user_id, telescope_data)
+
+    assert telescope is not None
+    assert telescope["telescope_type"] == equipment_profiles.TelescopeType.RASA.value
+    assert telescope["native_focal_ratio"] == 2.22
+
 def test_get_telescope(temp_data_dir, test_user_id):
     """Test retrieving a telescope profile"""
     telescope_data = {


### PR DESCRIPTION
## Description

Adds RASA (Rowe Ackerman Schmidt Astrograph) as an option for telescope type.

## Type of Change

<!-- Check all that apply by placing an 'x' in the brackets: [x] -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change (CSS, templates, visual improvements)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update (adding or updating tests)
- [ ] 🔧 Configuration change (Docker, CI/CD, build config)

## Related Issues

Closes #119

## Screenshots (if applicable)

## Checklist

### Code Quality

- [x] My code follows the [project style guidelines](../CONTRIBUTING.md#style-guidelines)
- [x] All code, comments, and documentation are **in English**, and updated according my changes
- [x] I have added/updated code comments where necessary, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have used the centralized logging system (no `print()` statements in backend)

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested in a Docker container
- [ ] I have verified no regressions in existing functionality

### Dependencies

- [ ] I have updated `requirements(-dev|-build).txt` if I added new Python dependencies

### Git Hygiene

- [x] My commits follow the [project commit conventions](../CONTRIBUTING.md#git-commit-messages)
- [x] I have rebased my branch on the latest main
- [x] I have resolved any merge conflicts
- [x] My branch name follows the convention (`feature/`, `fix/`, etc.)

### CI/CD

- [x] All CI checks pass
- [x] No new linting errors introduced
- [ ] Docker image builds successfully
- [x] No security vulnerabilities introduced

## Breaking Changes

**Is this a breaking change?** No